### PR TITLE
Issue #258: Three Ubuntu 24 issues

### DIFF
--- a/specs/src/setup.py
+++ b/specs/src/setup.py
@@ -220,7 +220,7 @@ clear_clean_nt = \
 """
 clean:
 	del /S *.d *.o *.obj
-	del /q $(EXE_DIR)\*
+	del /q $(EXE_DIR)\\*
 	rmdir $(EXE_DIR)
 	
 clear:

--- a/specs/src/specitems/InputPart.cc
+++ b/specs/src/specitems/InputPart.cc
@@ -169,7 +169,7 @@ std::string ClockPart::Debug()
 
 PSpecString ClockPart::getStr(ProcessingState& pState)
 {
-	clockValue timeStamp;
+	clockValue timeStamp = 0;
 	switch (m_Type) {
 	case ClockType__Static:
 		timeStamp = m_StaticClock;


### PR DESCRIPTION
 1. An un-escaped backslash in setup.py (python 3.12 issue)
 2. Deprecated calls in PythonIntf.cc (python 3.12 and 3.11 issue)
 3. Uninitialized variable in InputPart.cc - new compiler issue