### PR TITLE
feat: display Python error details by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ What's new:
  * .pkg package for Mac OS
  * RPM for Linux
  * .deb package for Ubuntu/Debian
- * Homebrew formula
+ * Visual Studio infra for building for Windows
  * Improved guessing of Python version
  * New spec units: `SPLITW` and `SPLITF` for splitting input records by words or fields into multiple output records. These new spec units support optional custom separators, `OF` clauses (with the same semantics as SUBSTRING), and range output placement (e.g. `splitw 1-10`).
  * A more exact `exact()` function
@@ -39,6 +39,15 @@ To download your copy of *specs*, you can get it from [github](https://github.co
 1. Using git: `git clone https://github.com/yoavnir/specs2016.git`
 2. Using http: `wget https://github.com/yoavnir/specs2016/archive/dev.zip`
 
+Installation from binaries
+==========================
+The binaries for the latest release can be downloaded from [**the release page**](https://github.com/yoavnir/specs2016/releases/tag/v0.9.9)
+
+Limitations:
+ * You will not get any Python support for Python integration on Windows
+ * You may get an older version of Python for Python integration on other platforms
+ * No support for exotic OS-es like Windows on ARM.
+
 Building
 ========
 If you have downloaded a git repository, first make sure to check out a stable tag such as v0.9.9:
@@ -56,7 +65,10 @@ After that, _cd_ to the specs/src directory, and run the following three command
 * `make some`
 * `sudo make install`
 
-*Note:* Windows does not need `sudo`. 
+*Note:* For Microsoft Windows, you can use **MSBuild** as follows:
+* Start from the repository directory (do not _cd_ to specs/src)
+* `msbuild specs/specs.sln /p:Configuration=Release /p:Platform=x64`
+* Now copy the resulting `specs.exe` to a target directory in the path. 
 
 *Note:* Only Python 3 is supported at this point. To enable Python support, you need to have the `python3-devel` package that matches your python version installed.
 

--- a/README.md
+++ b/README.md
@@ -40,32 +40,11 @@ To download your copy of *specs*, you can get it from [github](https://github.co
 
 Installation from binaries
 ==========================
-The binaries for the latest release can be downloaded from [**the release page**](https://github.com/yoavnir/specs2016/releases/tag/v0.9.9)
-
-Limitations:
- * You will not get any Python support for Python integration on Windows
- * You may get an older version of Python for Python integration on other platforms
- * No support for exotic OS-es like Windows on ARM.
-
-Building
-If you have downloaded a git repository, first make sure to check out a stable tag such as v0.9.9:
-```
-git checkout v0.9.9
-```
-A good way to get the latest stable release is to check out the `stable` branch and rebase to its tip:
-```
-git checkout stable
-git rebase
-```
 The binaries for the latest release can be downloaded from [**the release page**](https://github.com/yoavnir/specs2016/releases/tag/v1.0.0)
 
 **Requirements:**
  * **Python 3.12 must be installed on your target machine.** All pre-built binaries (Linux RPM, Linux DEB, macOS .pkg, and Windows MSI/executable) are dynamically linked against Python 3.12.
 
-*Note:* For Microsoft Windows, you can use **MSBuild** as follows:
-* Start from the repository directory (do not _cd_ to specs/src)
-* `msbuild specs/specs.sln /p:Configuration=Release /p:Platform=x64`
-* Now copy the resulting `specs.exe` to a target directory in the path. 
 **Notes:**
  * On Windows for ARM, you may install the x64 version of Python 3.12.
  * Recent Mac OS versions are very strict on where packages come from.  You may need to issue the following command to get the .pkg file to install: `xattr -dr com.apple.quarantine /path/to/specs-1.0.0.pkg`

--- a/specs/src/utils/PythonIntf.cc
+++ b/specs/src/utils/PythonIntf.cc
@@ -330,7 +330,7 @@ public:
 			} else {
 				std::cerr << "Python Interface: Error loading local functions: " << std::endl;
 				PyErr_Print();
-				MYTHROW("Error loading local functions");
+				exit(0);
 			}
 		}
 

--- a/specs/src/utils/PythonIntf.cc
+++ b/specs/src/utils/PythonIntf.cc
@@ -328,10 +328,8 @@ public:
 				m_Initialized = true;
 				return;
 			} else {
-				if (g_bVerbose) {
-					std::cerr << "Python Interface: Error loading local functions: ";
-					PyErr_Print();
-				}
+				std::cerr << "Python Interface: Error loading local functions: " << std::endl;
+				PyErr_Print();
 				MYTHROW("Error loading local functions");
 			}
 		}


### PR DESCRIPTION
Moved PyErr_Print() outside of the verbose flag check in PythonIntf.cc.
This ensures that users can see specific Python errors (like SyntaxError) 
without needing to enable verbose mode (-v), making troubleshooting much easier.

Fixes #370